### PR TITLE
fix: make decode routine browser compatible

### DIFF
--- a/src/decodeCert.js
+++ b/src/decodeCert.js
@@ -2,7 +2,7 @@ import path from 'path'
 import base64url from 'base64url'
 import decodeUriComponent from 'decode-uri-component'
 import untildify from 'untildify'
-
+import { isAbsolute } from './utils'
 /**
  * decode a tls certificate from a base64 encoded url string.
  * @param  {String} certString base64url encoded string to decode
@@ -15,7 +15,7 @@ const decodeCert = certString => {
 
   const unescaped = decodeUriComponent(certString)
 
-  if (path.isAbsolute(untildify(unescaped))) {
+  if (isAbsolute(untildify(unescaped))) {
     return unescaped
   }
 

--- a/src/decodeMacaroon.js
+++ b/src/decodeMacaroon.js
@@ -2,6 +2,7 @@ import path from 'path'
 import base64url from 'base64url'
 import decodeUriComponent from 'decode-uri-component'
 import untildify from 'untildify'
+import { isAbsolute } from './utils'
 
 /**
  * decode a binary macaroon as a base64 decoded url string.
@@ -15,7 +16,7 @@ const decodeMacaroon = macaroonString => {
 
   const unescaped = decodeUriComponent(macaroonString)
 
-  if (path.isAbsolute(untildify(unescaped))) {
+  if (isAbsolute(untildify(unescaped))) {
     return unescaped
   }
 

--- a/src/encodeCert.js
+++ b/src/encodeCert.js
@@ -14,7 +14,7 @@ const encodeCert = (input, format = 'utf8') => {
 
   var cert = new Buffer.from(input, format).toString('utf8')
 
-  let lines = cert.split(/\n/)
+  let lines = cert.split(/[\r\n]+/)
   lines = lines.filter(line => line != '')
 
   // If its a cert, strip out the header and footer and bes64url encode it.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,35 @@
+/**
+ * Cross platform isAbsolute path routine extracted from node JS code
+ */
+
+const CHAR_UPPERCASE_A = 65 /* A */
+const CHAR_LOWERCASE_A = 97 /* a */
+const CHAR_UPPERCASE_Z = 90 /* Z */
+const CHAR_LOWERCASE_Z = 122 /* z */
+
+const CHAR_FORWARD_SLASH = 47 /* / */
+const CHAR_BACKWARD_SLASH = 92
+
+const CHAR_COLON = 58
+
+function isWindowsDeviceRoot(code) {
+  return (
+    (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) || (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)
+  )
+}
+
+function isPathSeparator(code) {
+  return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH
+}
+
+export function isAbsolute(path) {
+  const len = path.length
+  if (len === 0) return false
+
+  const code = path.charCodeAt(0)
+  return (
+    isPathSeparator(code) ||
+    // Possible device root
+    (len > 2 && isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON && isPathSeparator(path.charCodeAt(2)))
+  )
+}


### PR DESCRIPTION
Currently, decode functionality is broken in browser env because of path.isAbsolute polyfill using posix fallback. This PR also fixes usage unix specific line separator, which was resulting in incorrect functionality on Windows.