### PR TITLE
Run build with production env

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "babel-tape-runner test/*.js | tap-spec",
     "lint": "prettier-eslint --write \"./**/*.{js,json,md}\"",
-    "build": "npm run clean && babel src --out-dir dist",
+    "build": "npm run clean && NODE_ENV=production babel src --out-dir dist",
     "clean": "rimraf -r ./dist",
     "preversion": "npm test",
     "prepack": "npm run build && cp dist/*.js .",


### PR DESCRIPTION
Otherwise the transpiled code requires the source-map-support module (see .babelrc), which is missing when node-lndconnect is installed as a devendency. (because source-map-support is a `devDependency` here, which is correct – but it should not be required in production code)